### PR TITLE
Fix: 거래 상세 페이지 리다이렉트 시 google map api 키 전송 누락 해결

### DIFF
--- a/src/main/java/com/owl/trade_market/config/SecurityConfig.java
+++ b/src/main/java/com/owl/trade_market/config/SecurityConfig.java
@@ -81,8 +81,8 @@ public class SecurityConfig {
                         .logoutUrl("/logout")
                         .logoutSuccessUrl("/main")
                         .permitAll()
-                )
-                .csrf(csrf -> csrf.disable());
+                );
+//                .csrf(csrf -> csrf.disable());
 
         return http.build();
     }

--- a/src/main/java/com/owl/trade_market/controller/ProductController.java
+++ b/src/main/java/com/owl/trade_market/controller/ProductController.java
@@ -312,6 +312,8 @@ public class ProductController {
                                 Model model) {
 
         User user = getCurrentUser(session, oauth2User);
+        // Google Map API 키 주입
+        model.addAttribute("googleMapsApiKey", googleMapsApiKey);
         if (user == null) {
             redirectAttributes.addFlashAttribute("error", "로그인이 필요합니다.");
             return "redirect:/users/login";


### PR DESCRIPTION
get요청 시에만 키를 전송했기때문에 생긴 문제였음. post요청시에도 키를 전송하는 것으로 해결